### PR TITLE
Enable i18next language detection middleware

### DIFF
--- a/src/api/routes/v1/util/i18n.ts
+++ b/src/api/routes/v1/util/i18n.ts
@@ -11,6 +11,8 @@ const resources = {
 }
 
 // Initialize i18next
+i18next.use(i18nextHttpMiddleware.LanguageDetector)
+
 i18next.init({
   resources,
   lng: "en", // default language


### PR DESCRIPTION
## Summary
- Register i18next-http-middleware LanguageDetector before initialization to enable language detection

## Testing
- `npm test` (fails: Missing script "test")
- `curl -H 'Accept-Language: uk' -s http://localhost:3000/ -i`

------
https://chatgpt.com/codex/tasks/task_e_689500ab1c948325a6d798c443297639