### PR TITLE
Localize notification router messages

### DIFF
--- a/src/api/locale/en.json
+++ b/src/api/locale/en.json
@@ -19,5 +19,10 @@
     "confirm": "Confirm",
     "yes": "Yes",
     "no": "No"
+  },
+  "notifications": {
+    "invalidFormatting": "Invalid formatting",
+    "invalidNotification": "Invalid notification",
+    "success": "Success"
   }
-} 
+}

--- a/src/api/locale/uk.json
+++ b/src/api/locale/uk.json
@@ -19,5 +19,10 @@
     "confirm": "Підтвердити",
     "yes": "Так",
     "no": "Ні"
+  },
+  "notifications": {
+    "invalidFormatting": "Некоректне форматування",
+    "invalidNotification": "Некоректне сповіщення",
+    "success": "Успіх"
   }
-} 
+}

--- a/src/api/routes/v1/notifications/notification.ts
+++ b/src/api/routes/v1/notifications/notification.ts
@@ -12,7 +12,7 @@ notificationRouter.post("/update", userAuthorized, async (req, res, next) => {
 
   for (const { notification_id, read } of values) {
     if (!notification_id || !read) {
-      res.status(400).json({ error: "Invalid formatting" })
+      res.status(400).json({ error: req.t("notifications.invalidFormatting") })
       return
     }
 
@@ -22,7 +22,7 @@ notificationRouter.post("/update", userAuthorized, async (req, res, next) => {
     })
 
     if (!notifications.length) {
-      res.status(400).json({ error: "Invalid notification" })
+      res.status(400).json({ error: req.t("notifications.invalidNotification") })
       return
     }
 
@@ -32,7 +32,7 @@ notificationRouter.post("/update", userAuthorized, async (req, res, next) => {
     )
   }
 
-  res.json({ status: "Success" })
+  res.json({ status: req.t("notifications.success") })
 })
 
 notificationRouter.post("/delete", userAuthorized, async (req, res, next) => {
@@ -45,12 +45,12 @@ notificationRouter.post("/delete", userAuthorized, async (req, res, next) => {
     })
 
     if (!notification_id) {
-      res.status(400).json({ error: "Invalid formatting" })
+      res.status(400).json({ error: req.t("notifications.invalidFormatting") })
       return
     }
 
     if (!notifications.length) {
-      res.status(400).json({ error: "Invalid notification" })
+      res.status(400).json({ error: req.t("notifications.invalidNotification") })
       return
     }
 
@@ -60,7 +60,7 @@ notificationRouter.post("/delete", userAuthorized, async (req, res, next) => {
     })
   }
 
-  res.json({ status: "Success" })
+  res.json({ status: req.t("notifications.success") })
 })
 
 notificationRouter.get("/:page", userAuthorized, async (req, res, next) => {


### PR DESCRIPTION
## Summary
- use translation keys in notification router responses
- add notification message keys for English and Ukrainian locales

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68965bb8aa88832582559f33c0ef8a5d