### PR TITLE
Localize comment route messages

### DIFF
--- a/src/api/locale/en.json
+++ b/src/api/locale/en.json
@@ -26,7 +26,8 @@
     "success": "Success"
   },
   "errors": {
-    "missingPermissions": "Missing permissions"
+    "missingPermissions": "Missing permissions",
+    "noPermissions": "No permissions"
   },
   "auth": {
     "unauthenticated": "Unauthenticated"
@@ -38,7 +39,11 @@
     "invalidPost": "Invalid post",
     "invalidComment": "Invalid comment"
   },
+  "comments": {
+    "invalid": "Invalid comment",
+    "invalidArgument": "Invalid argument"
+  },
   "success": {
-    "generic": "Success!"
+    "generic": "Success"
   }
 }

--- a/src/api/locale/uk.json
+++ b/src/api/locale/uk.json
@@ -26,7 +26,8 @@
     "success": "Успіх"
   },
   "errors": {
-    "missingPermissions": "Недостатньо прав"
+    "missingPermissions": "Недостатньо прав",
+    "noPermissions": "Немає прав"
   },
   "auth": {
     "unauthenticated": "Не авторизовано"
@@ -38,7 +39,11 @@
     "invalidPost": "Некоректний пост",
     "invalidComment": "Некоректний коментар"
   },
+  "comments": {
+    "invalid": "Некоректний коментар",
+    "invalidArgument": "Некоректний аргумент"
+  },
   "success": {
-    "generic": "Успіх!"
+    "generic": "Успіх"
   }
 }

--- a/src/api/routes/v1/comments/comments.ts
+++ b/src/api/routes/v1/comments/comments.ts
@@ -18,7 +18,7 @@ commentRouter.post(
     const user = req.user as User
 
     if (!comment) {
-      res.status(400).json({ message: "Invalid comment" })
+      res.status(400).json({ message: req.t("comments.invalid") })
       return
     }
 
@@ -47,17 +47,17 @@ commentRouter.post(
     const user = req.user as User
 
     if (!comment) {
-      res.status(400).json({ message: "Invalid comment" })
+      res.status(400).json({ message: req.t("comments.invalid") })
       return
     }
 
     if (comment.author !== user.user_id && user.role !== "admin") {
-      res.status(400).json({ message: "No permissions" })
+      res.status(400).json({ message: req.t("errors.noPermissions") })
       return
     }
 
     await database.updateComments({ comment_id }, { deleted: true })
-    res.json({ message: "Success" })
+    res.json({ message: req.t("success.generic") })
   },
 )
 
@@ -71,12 +71,12 @@ commentRouter.post(
     const user = req.user as User
 
     if (!comment) {
-      res.status(400).json({ message: "Invalid comment" })
+      res.status(400).json({ message: req.t("comments.invalid") })
       return
     }
 
     if (comment.author !== user.user_id && user.role !== "admin") {
-      res.status(400).json({ message: "No permissions" })
+      res.status(400).json({ message: req.t("errors.noPermissions") })
       return
     }
 
@@ -87,12 +87,12 @@ commentRouter.post(
     } = req.body
 
     if (!content) {
-      res.status(400).json({ message: "Invalid argument" })
+      res.status(400).json({ message: req.t("comments.invalidArgument") })
       return
     }
 
     await database.updateComments({ comment_id }, { content })
-    res.json({ message: "Success" })
+    res.json({ message: req.t("success.generic") })
   },
 )
 
@@ -106,7 +106,7 @@ commentRouter.post(
     const user = req.user as User
 
     if (!comment) {
-      res.status(400).json({ message: "Invalid comment" })
+      res.status(400).json({ message: req.t("comments.invalid") })
       return
     }
 
@@ -123,7 +123,7 @@ commentRouter.post(
       })
     }
 
-    res.json({ message: "Success" })
+    res.json({ message: req.t("success.generic") })
   },
 )
 
@@ -137,7 +137,7 @@ commentRouter.post(
     const user = req.user as User
 
     if (!comment) {
-      res.status(400).json({ message: "Invalid comment" })
+      res.status(400).json({ message: req.t("comments.invalid") })
       return
     }
 
@@ -154,6 +154,6 @@ commentRouter.post(
       })
     }
 
-    res.json({ message: "Success" })
+    res.json({ message: req.t("success.generic") })
   },
 )


### PR DESCRIPTION
## Summary
- replace hard-coded comment route responses with `req.t` translation lookups
- add translation keys for comment errors, permission errors, and generic success in English and Ukrainian locales

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689662b1cc7c8325b7196e8938851d7e