### PR TITLE
Localize market helper messages and add market i18n keys

### DIFF
--- a/src/api/locale/en.json
+++ b/src/api/locale/en.json
@@ -58,6 +58,14 @@
     "invalidService": "Invalid service",
     "invalidPhoto": "Invalid photo"
   },
+  "market": {
+    "invalidListing": "Invalid listing",
+    "invalidQuantity": "Invalid quantity",
+    "buyOwnItem": "You cannot buy your own item!",
+    "itemsDifferentSellers": "All items must be from same seller",
+    "cannotUpdateArchived": "Cannot update archived listing",
+    "missingFields": "Missing required fields"
+  },
   "success": {
     "generic": "Success"
   }

--- a/src/api/locale/uk.json
+++ b/src/api/locale/uk.json
@@ -58,6 +58,14 @@
     "invalidService": "Некоректна послуга",
     "invalidPhoto": "Некоректне фото"
   },
+  "market": {
+    "invalidListing": "Некоректне оголошення",
+    "invalidQuantity": "Некоректна кількість",
+    "buyOwnItem": "Ви не можете купити власний товар!",
+    "itemsDifferentSellers": "Усі товари повинні бути від одного продавця",
+    "cannotUpdateArchived": "Неможливо оновити архівоване оголошення",
+    "missingFields": "Відсутні необхідні поля"
+  },
   "success": {
     "generic": "Успіх"
   }

--- a/src/api/routes/v1/market/helpers.ts
+++ b/src/api/routes/v1/market/helpers.ts
@@ -61,6 +61,7 @@ export function sameSeller(listings: DBMarketListing[]) {
 }
 
 export async function verify_listings(
+  req: Request,
   res: Response,
   items: { listing_id: string; quantity: number }[],
   user: User,
@@ -77,27 +78,27 @@ export async function verify_listings(
     try {
       listing = await database.getMarketListingComplete(listing_id)
     } catch {
-      res.status(400).json({ error: "Invalid listing" })
+      res.status(400).json({ error: req.t("market.invalidListing") })
       return
     }
 
     if (!listing) {
-      res.status(400).json({ error: "Invalid listing" })
+      res.status(400).json({ error: req.t("market.invalidListing") })
       return
     }
 
     if (listing.listing.status !== "active") {
-      res.status(404).json({ error: "Invalid listing" })
+      res.status(404).json({ error: req.t("market.invalidListing") })
       return
     }
 
     if (listing.listing.quantity_available < quantity || quantity < 1) {
-      res.status(400).json({ error: "Invalid quantity" })
+      res.status(400).json({ error: req.t("market.invalidQuantity") })
       return
     }
 
     if (listing.listing.user_seller_id === user.user_id) {
-      res.status(400).json({ error: "You cannot buy your own item!" })
+      res.status(400).json({ error: req.t("market.buyOwnItem") })
       return
     }
 
@@ -105,7 +106,7 @@ export async function verify_listings(
   }
 
   if (!sameSeller(listings.map((u) => u.listing.listing))) {
-    res.status(400).json({ message: "All items must be from same seller" })
+    res.status(400).json({ message: req.t("market.itemsDifferentSellers") })
     return
   }
 
@@ -242,7 +243,8 @@ export async function get_org_listings(contractor: DBContractor) {
 }
 
 export async function handle_quantity_update(
-  res: any,
+  req: Request,
+  res: Response,
   user: User,
   listing: DBMarketListing,
   quantity_available: number,
@@ -276,23 +278,23 @@ export async function handle_quantity_update(
   }
 
   if (listing.status === "archived") {
-    res.status(400).json({ error: "Cannot update archived listing" })
+    res.status(400).json({ error: req.t("market.cannotUpdateArchived") })
     return
   }
 
   if (quantity_available === undefined) {
-    res.status(400).json({ error: "Missing required fields" })
+    res.status(400).json({ error: req.t("market.missingFields") })
     return
   }
 
   if (quantity_available < 0) {
-    res.status(400).json({ error: "Invalid quantity" })
+    res.status(400).json({ error: req.t("market.invalidQuantity") })
     return
   }
 
   await database.updateMarketListing(listing.listing_id, { quantity_available })
 
-  res.json({ result: "Success" })
+  res.json({ result: req.t("success.generic") })
 }
 
 export function formatListingSlug(title: string) {

--- a/src/api/routes/v1/market/market.ts
+++ b/src/api/routes/v1/market/market.ts
@@ -566,7 +566,7 @@ marketRouter.post(
       return
     }
 
-    await handle_quantity_update(res, user, listing, quantity_available)
+    await handle_quantity_update(req, res, user, listing, quantity_available)
   },
 )
 
@@ -1147,7 +1147,7 @@ marketRouter.post(
         return
       }
 
-      const listings = await verify_listings(res, items, user)
+      const listings = await verify_listings(req, res, items, user)
       if (listings === undefined) {
         return
       }

--- a/src/api/routes/v1/offers/offers.ts
+++ b/src/api/routes/v1/offers/offers.ts
@@ -241,7 +241,8 @@ oapi.schema("OfferSessionDetails", {
     order_id: {
       type: "string",
       nullable: true,
-      description: "Order ID associated with this offer session when status is 'Accepted'",
+      description:
+        "Order ID associated with this offer session when status is 'Accepted'",
       example: "123e4567-e89b-12d3-a456-426614174000",
     },
     offers: {
@@ -642,6 +643,7 @@ offerRouter.put(
       const body = req.body as CounterOfferBody
 
       const listings = await verify_listings(
+        req,
         res,
         body.market_listings,
         customer,

--- a/src/clients/discord_api/threads.ts
+++ b/src/clients/discord_api/threads.ts
@@ -155,7 +155,7 @@ threadRouter.post("/market/quantity/:opt", async (req, res) => {
     }
   }
 
-  await handle_quantity_update(res, user, listing, new_quantity)
+  await handle_quantity_update(req, res, user, listing, new_quantity)
 })
 
 threadRouter.get("/user/:discord_id/assigned", async (req, res) => {


### PR DESCRIPTION
## Summary
- use `req.t` for market helper error/success messages
- add market translation keys in English and Ukrainian
- pass `req` through call sites