### PR TITLE
Localize wiki short query error

### DIFF
--- a/src/api/locale/en.json
+++ b/src/api/locale/en.json
@@ -95,6 +95,9 @@
     "itemNameRequired": "Item name is required",
     "gameItemNotFound": "Game item not found"
   },
+  "wiki": {
+    "queryTooShort": "Query too short"
+  },
   "success": {
     "generic": "Success"
   }

--- a/src/api/locale/uk.json
+++ b/src/api/locale/uk.json
@@ -95,6 +95,9 @@
     "itemNameRequired": "Потрібна назва товару",
     "gameItemNotFound": "Ігровий предмет не знайдено"
   },
+  "wiki": {
+    "queryTooShort": "Запит занадто короткий"
+  },
   "success": {
     "generic": "Успіх"
   }

--- a/src/api/routes/v1/wiki/wiki.ts
+++ b/src/api/routes/v1/wiki/wiki.ts
@@ -103,7 +103,7 @@ wikiRouter.get("/imagesearch/:query", async function (req, res) {
     const query = req.params["query"]
 
     if (query.length < 3) {
-      res.status(400).json({ error: "Too short" })
+      res.status(400).json({ error: req.t("wiki.queryTooShort") })
       return
     }
 
@@ -128,7 +128,7 @@ wikiRouter.get("/itemsearch/:query", async function (req, res) {
   const query = req.params["query"]
 
   if (query.length < 3) {
-    res.status(400).json({ error: "Too short" })
+    res.status(400).json({ error: req.t("wiki.queryTooShort") })
     return
   }
 


### PR DESCRIPTION
## Summary
- use translation key for wiki short query error messages
- add `wiki.queryTooShort` translations for English and Ukrainian

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689670199e4083259a64bd20011d8160