### PR TITLE
Use translations for chat routes

### DIFF
--- a/src/api/locale/en.json
+++ b/src/api/locale/en.json
@@ -45,6 +45,11 @@
     "invalid": "Invalid comment",
     "invalidArgument": "Invalid argument"
   },
+  "chats": {
+    "invalid": "Invalid chat",
+    "invalidContent": "Invalid content",
+    "invalidUser": "Invalid user"
+  },
   "transactions": {
     "invalid": "Invalid transaction",
     "missingFields": "Missing required fields",

--- a/src/api/locale/uk.json
+++ b/src/api/locale/uk.json
@@ -45,6 +45,11 @@
     "invalid": "Некоректний коментар",
     "invalidArgument": "Некоректний аргумент"
   },
+  "chats": {
+    "invalid": "Некоректний чат",
+    "invalidContent": "Некоректний вміст",
+    "invalidUser": "Некоректний користувач"
+  },
   "transactions": {
     "invalid": "Некоректна транзакція",
     "missingFields": "Відсутні необхідні поля",

--- a/src/api/routes/v1/chats/chats.ts
+++ b/src/api/routes/v1/chats/chats.ts
@@ -167,7 +167,9 @@ chatsRouter.get(
     try {
       chat = await database.getChat({ order_id: req.params.order_id })
     } catch {
-      res.status(404).json(createErrorResponse({ error: "Invalid chat" }))
+      res
+        .status(404)
+        .json(createErrorResponse({ error: req.t("chats.invalid") }))
       return
     }
 
@@ -223,7 +225,9 @@ chatsRouter.get(
     try {
       chat = await database.getChat({ session_id: session_id })
     } catch {
-      res.status(404).json(createErrorResponse({ error: "Invalid chat" }))
+      res
+        .status(404)
+        .json(createErrorResponse({ error: req.t("chats.invalid") }))
       return
     }
 
@@ -296,10 +300,12 @@ chatsRouter.post(
       content: string
     }
 
-    if (!content) {
-      res.status(400).json(createErrorResponse({ error: "Invalid content" }))
-      return
-    }
+      if (!content) {
+        res
+          .status(400)
+          .json(createErrorResponse({ error: req.t("chats.invalidContent") }))
+        return
+      }
 
     const chat = req.chat!
 
@@ -327,7 +333,7 @@ chatsRouter.post(
       }
     }
 
-    res.json(createResponse({ result: "Success" }))
+      res.json(createResponse({ result: req.t("success.generic") }))
   },
 )
 
@@ -389,11 +395,13 @@ chatsRouter.post(
       }),
     )
 
-    // TODO: Process blocked users and user access settings
-    if (!users.every(Boolean)) {
-      res.status(400).json(createErrorResponse({ error: "Invalid user!" }))
-      return
-    }
+      // TODO: Process blocked users and user access settings
+      if (!users.every(Boolean)) {
+        res
+          .status(400)
+          .json(createErrorResponse({ error: req.t("chats.invalidUser") }))
+        return
+      }
 
     users.push(user)
 

--- a/src/api/routes/v1/chats/middleware.ts
+++ b/src/api/routes/v1/chats/middleware.ts
@@ -19,10 +19,12 @@ export async function valid_chat(
   let chat
   try {
     chat = await database.getChat({ chat_id: req.params.chat_id })
-  } catch {
-    res.status(404).json(createErrorResponse({ error: "Invalid chat" }))
-    return
-  }
+    } catch {
+      res
+        .status(404)
+        .json(createErrorResponse({ error: req.t("chats.invalid") }))
+      return
+    }
 
   req.chat = chat
   next()
@@ -72,9 +74,11 @@ export async function related_to_chat(
 
   const result = await can_view_chat(user, chat)
 
-  if (!result.result) {
-    res.status(403).json(createErrorResponse({ error: "Not authorized" }))
-  }
+    if (!result.result) {
+      res
+        .status(403)
+        .json(createErrorResponse({ error: req.t("errors.notAuthorized") }))
+    }
 
   req.order = result.order || undefined
   req.offer_session = result.offer_session || undefined


### PR DESCRIPTION
## Summary
- replace hard-coded chat errors and responses with `req.t` lookups
- add missing chat translation keys for English and Ukrainian