### PR TITLE
Localize offer-related error messages

### DIFF
--- a/src/api/locale/en.json
+++ b/src/api/locale/en.json
@@ -124,6 +124,11 @@
   "success": {
     "generic": "Success"
   },
+  "offers": {
+    "invalidService": "Invalid service",
+    "threadExists": "Offer already has a thread",
+    "invalidOffer": "Invalid offer"
+  },
   "orders": {
     "invalidStatus": "Invalid status",
     "closedStatusChange": "Cannot change status for closed order",

--- a/src/api/locale/uk.json
+++ b/src/api/locale/uk.json
@@ -124,6 +124,11 @@
   "success": {
     "generic": "Успіх"
   },
+  "offers": {
+    "invalidService": "Некоректна послуга",
+    "threadExists": "Пропозиція вже має тему",
+    "invalidOffer": "Некоректна пропозиція"
+  },
   "orders": {
     "invalidStatus": "Некоректний статус",
     "closedStatusChange": "Неможливо змінити статус закритого замовлення",

--- a/src/api/routes/v1/offers/middleware.ts
+++ b/src/api/routes/v1/offers/middleware.ts
@@ -17,7 +17,9 @@ export async function related_to_offer(
   try {
     ;[offer] = await database.getOfferSessions({ id: id })
   } catch (e) {
-    res.status(404).json(createErrorResponse({ error: "Invalid offer" }))
+    res
+      .status(404)
+      .json(createErrorResponse({ error: req.t("offers.invalidOffer") }))
     return
   }
 
@@ -37,11 +39,11 @@ export async function related_to_offer(
   }
 
   if (unrelated) {
-    res.status(403).json(
-      createErrorResponse({
-        error: "You are not authorized to view this offer",
-      }),
-    )
+    res
+      .status(403)
+      .json(
+        createErrorResponse({ error: req.t("errors.notAuthorized") }),
+      )
     return
   }
 
@@ -68,11 +70,11 @@ export async function can_respond_to_offer(
   }
 
   if (!related) {
-    res.status(403).json(
-      createErrorResponse({
-        error: "You are not authorized to respond to this offer",
-      }),
-    )
+    res
+      .status(403)
+      .json(
+        createErrorResponse({ error: req.t("errors.notAuthorized") }),
+      )
   }
 
   next()


### PR DESCRIPTION
## Summary
- use `req.t` for offer error and permission messages
- add English and Ukrainian translations for offer errors