### PR TITLE
Localization: replace all user-facing literals with req.t(key) per author docs (batched, auth/profiles/orders/offers)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "dev": "tsx watch src/server.ts",
     "buildrun": "build && start",
     "start": "tsx watch src/server.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "tsx --test tests/**/*.test.ts"
   },
   "eslintConfig": {
     "root": true,

--- a/src/api/locale/en.json
+++ b/src/api/locale/en.json
@@ -126,7 +126,18 @@
     "cannotFulfillOwnOrder": "Can't fulfill own order",
     "invalidBuyOrder": "Invalid buy order",
     "itemNameRequired": "Item name is required",
-    "gameItemNotFound": "Game item not found"
+    "gameItemNotFound": "Game item not found",
+    "delivery": {
+      "itemSoldTitle": "Item Sold: {{title}} (x{{quantity}}) to {{username}}",
+      "itemSoldDescription": "Complete the delivery of sold item {{title}} (x{{quantity}}) to {{username}}\n\n{{description}}",
+      "completeMessage": "Complete the delivery of sold items to [{{username}}](https://sc-market.space/user/{{username}})\n",
+      "listItem": "- [{{title}}](https://sc-market.space/market/{{listingId}}) ({{price}} aUEC x{{quantity}})\n",
+      "total": "- Total: {{total}} aUEC\n",
+      "userOffer": "- User Offer: {{offer}} aUEC\n",
+      "noteFromBuyer": "\nNote from buyer:\n> {{note}}",
+      "none": "None",
+      "itemsSoldTitle": "Items Sold to {{username}}"
+    }
   },
   "wiki": {
     "queryTooShort": "Query too short"
@@ -165,5 +176,37 @@
     "localeUpdated": "Locale updated successfully",
     "userAlreadyRegistered": "User already registered",
     "codeNotFound": "Code not found"
+  },
+  "discord": {
+    "userDetails": "Discord User Details: <@{{discordId}}>\n\n{{description}}",
+    "status": {
+      "was": "Was: {{status}}",
+      "orderUpdated": "Order Status Updated - {{status}}",
+      "offerUpdated": "Offer Status Updated - {{status}}"
+    },
+    "assigned": {
+      "description": "Someone has been assigned to fulfill this order",
+      "title": "Order Assigned - {{username}}"
+    },
+    "fields": {
+      "offer": "Offer",
+      "kind": "Kind",
+      "collateral": "Collateral",
+      "rush": "Rush",
+      "bidAmount": "Bid Amount",
+      "comment": "Comment",
+      "newStatus": "New Status"
+    },
+    "usernames": {
+      "orderPlaced": "SC Market - Order Placed",
+      "offerReceived": "Offer Received",
+      "counterOfferReceived": "Counter Offer Received",
+      "bidReceived": "SC Market - Bid Received",
+      "orderCommentReceived": "SC Market - Order Comment Received",
+      "orderStatusUpdated": "SC Market - Order Status Updated"
+    },
+    "thread": {
+      "orderName": "order-{{id}}"
+    }
   }
 }

--- a/src/api/locale/en.json
+++ b/src/api/locale/en.json
@@ -32,10 +32,16 @@
     "internalServer": "Internal server error",
     "unauthorized": "Unauthorized",
     "invalidUrl": "Invalid URL",
+    "invalidBody": "Invalid body",
+    "invalidArguments": "Invalid arguments",
+    "invalidActions": "Invalid actions",
+    "invalidUser": "Invalid user",
+    "invalidContractor": "Invalid contractor",
     "unknown": "An unknown error occurred"
   },
   "auth": {
-    "unauthenticated": "Unauthenticated"
+    "unauthenticated": "Unauthenticated",
+    "notVerified": "Your account is not verified."
   },
   "contracts": {
     "invalidContractor": "Invalid contractor",
@@ -153,6 +159,11 @@
   },
   "profiles": {
     "userNotFound": "User not found",
-    "updateLocaleFailed": "Failed to update user locale"
+    "updateLocaleFailed": "Failed to update user locale",
+    "noAccess": "No access",
+    "invalidDisplayName": "Invalid display name",
+    "localeUpdated": "Locale updated successfully",
+    "userAlreadyRegistered": "User already registered",
+    "codeNotFound": "Code not found"
   }
 }

--- a/src/api/locale/uk.json
+++ b/src/api/locale/uk.json
@@ -32,10 +32,16 @@
     "internalServer": "Внутрішня помилка сервера",
     "unauthorized": "Немає доступу",
     "invalidUrl": "Некоректний URL",
+    "invalidBody": "Некоректне тіло запиту",
+    "invalidArguments": "Некоректні аргументи",
+    "invalidActions": "Некоректні дії",
+    "invalidUser": "Некоректний користувач",
+    "invalidContractor": "Некоректний підрядник",
     "unknown": "Сталася невідома помилка"
   },
   "auth": {
-    "unauthenticated": "Не авторизовано"
+    "unauthenticated": "Не авторизовано",
+    "notVerified": "Ваш акаунт не підтверджено."
   },
   "contracts": {
     "invalidContractor": "Некоректний підрядник",
@@ -153,6 +159,11 @@
   },
   "profiles": {
     "userNotFound": "Користувача не знайдено",
-    "updateLocaleFailed": "Не вдалося оновити локаль користувача"
+    "updateLocaleFailed": "Не вдалося оновити локаль користувача",
+    "noAccess": "Немає доступу",
+    "invalidDisplayName": "Некоректне відображуване ім'я",
+    "localeUpdated": "Локаль успішно оновлено",
+    "userAlreadyRegistered": "Користувач вже зареєстрований",
+    "codeNotFound": "Код не знайдено"
   }
 }

--- a/src/api/locale/uk.json
+++ b/src/api/locale/uk.json
@@ -126,7 +126,18 @@
     "cannotFulfillOwnOrder": "Неможливо виконати власне замовлення",
     "invalidBuyOrder": "Некоректне замовлення на купівлю",
     "itemNameRequired": "Потрібна назва товару",
-    "gameItemNotFound": "Ігровий предмет не знайдено"
+    "gameItemNotFound": "Ігровий предмет не знайдено",
+    "delivery": {
+      "itemSoldTitle": "Продано товар: {{title}} (x{{quantity}}) для {{username}}",
+      "itemSoldDescription": "Завершіть доставку проданого товару {{title}} (x{{quantity}}) для {{username}}\n\n{{description}}",
+      "completeMessage": "Завершіть доставку проданих товарів до [{{username}}](https://sc-market.space/user/{{username}})\n",
+      "listItem": "- [{{title}}](https://sc-market.space/market/{{listingId}}) ({{price}} aUEC x{{quantity}})\n",
+      "total": "- Разом: {{total}} aUEC\n",
+      "userOffer": "- Пропозиція користувача: {{offer}} aUEC\n",
+      "noteFromBuyer": "\nПримітка від покупця:\n> {{note}}",
+      "none": "Немає",
+      "itemsSoldTitle": "Товари продані для {{username}}"
+    }
   },
   "wiki": {
     "queryTooShort": "Запит занадто короткий"
@@ -165,5 +176,37 @@
     "localeUpdated": "Локаль успішно оновлено",
     "userAlreadyRegistered": "Користувач вже зареєстрований",
     "codeNotFound": "Код не знайдено"
+  },
+  "discord": {
+    "userDetails": "Деталі користувача Discord: <@{{discordId}}>\n\n{{description}}",
+    "status": {
+      "was": "Було: {{status}}",
+      "orderUpdated": "Статус замовлення оновлено - {{status}}",
+      "offerUpdated": "Статус пропозиції оновлено - {{status}}"
+    },
+    "assigned": {
+      "description": "До цього замовлення призначено виконавця",
+      "title": "Замовлення призначено - {{username}}"
+    },
+    "fields": {
+      "offer": "Пропозиція",
+      "kind": "Тип",
+      "collateral": "Застава",
+      "rush": "Терміново",
+      "bidAmount": "Сума ставки",
+      "comment": "Коментар",
+      "newStatus": "Новий статус"
+    },
+    "usernames": {
+      "orderPlaced": "SC Market - Замовлення створено",
+      "offerReceived": "Отримано пропозицію",
+      "counterOfferReceived": "Отримано зустрічну пропозицію",
+      "bidReceived": "SC Market - Отримано ставку",
+      "orderCommentReceived": "SC Market - Отримано коментар до замовлення",
+      "orderStatusUpdated": "SC Market - Статус замовлення оновлено"
+    },
+    "thread": {
+      "orderName": "order-{{id}}"
+    }
   }
 }

--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express"
 import { User } from "../routes/v1/api-models.js"
+import { RequestWithI18n } from "../routes/v1/util/i18n.js"
 
 export function pageAuthentication(
   req: Request,
@@ -14,14 +15,14 @@ export function pageAuthentication(
 }
 
 export async function guestAuthorized(
-  req: Request,
+  req: RequestWithI18n,
   res: Response,
   next: NextFunction,
 ) {
   if (req.isAuthenticated()) {
     next()
   } else {
-    res.status(401).json({ error: "Unauthenticated" })
+    res.status(401).json({ error: req.t("auth.unauthenticated") })
   }
 }
 
@@ -43,7 +44,7 @@ export function errorHandler(
 }
 
 export async function userAuthorized(
-  req: Request,
+  req: RequestWithI18n,
   res: Response,
   next: NextFunction,
 ): Promise<void> {
@@ -51,18 +52,18 @@ export async function userAuthorized(
     if (req.isAuthenticated()) {
       const user = req.user as User
       if (user.banned) {
-        res.status(418).json({ error: "Internal server error" })
+        res.status(418).json({ error: req.t("errors.internalServer") })
         return
       }
       if (user.role === "user" || user.role === "admin") {
         next()
         return
       } else {
-        res.status(403).json({ error: "Unauthorized" })
+        res.status(403).json({ error: req.t("errors.unauthorized") })
         return
       }
     } else {
-      res.status(401).json({ error: "Unauthenticated" })
+      res.status(401).json({ error: req.t("auth.unauthenticated") })
       return
     }
   } catch (e) {
@@ -73,48 +74,48 @@ export async function userAuthorized(
 }
 
 export async function verifiedUser(
-  req: Request,
+  req: RequestWithI18n,
   res: Response,
   next: NextFunction,
 ) {
   if (req.isAuthenticated()) {
     const user = req.user as User
     if (user.banned) {
-      res.status(418).json({ error: "Internal server error" })
+      res.status(418).json({ error: req.t("errors.internalServer") })
       return
     }
     if (!user.rsi_confirmed) {
-      res.status(401).json({ error: "Your account is not verified." })
+      res.status(401).json({ error: req.t("auth.notVerified") })
       return
     } else {
       next()
       return
     }
   } else {
-    res.status(401).json({ error: "Unauthenticated" })
+    res.status(401).json({ error: req.t("auth.unauthenticated") })
     return
   }
 }
 
 export function adminAuthorized(
-  req: Request,
+  req: RequestWithI18n,
   res: Response,
   next: NextFunction,
 ): void {
   if (req.isAuthenticated()) {
     const user = req.user as User
     if (user.banned) {
-      res.status(418).json({ error: "Internal server error" })
+      res.status(418).json({ error: req.t("errors.internalServer") })
       return
     }
     if (user.role === "admin") {
       next()
     } else {
-      res.status(403).json({ error: "Unauthorized" })
+      res.status(403).json({ error: req.t("errors.unauthorized") })
       return
     }
   } else {
-    res.status(401).json({ error: "Unauthenticated" })
+    res.status(401).json({ error: req.t("auth.unauthenticated") })
   }
 }
 

--- a/src/api/routes/v1/market/market.ts
+++ b/src/api/routes/v1/market/market.ts
@@ -1153,23 +1153,30 @@ marketRouter.post(
       }
 
       let total = 0
-      let message = `Complete the delivery of sold items to [${user.username}](https://sc-market.space/user/${user.username})\n`
+      let message = req.t("market.delivery.completeMessage", {
+        username: user.username,
+      })
 
       for (const { quantity, listing } of listings) {
         total += quantity * +listing.listing.price
-        message += `- [${listing.details.title}](https://sc-market.space/market/${
-          listing.listing.listing_id
-        }) (${(+listing.listing.price).toLocaleString(
-          "en-us",
-        )} aUEC x${quantity.toLocaleString("en-us")})\n`
+        message += req.t("market.delivery.listItem", {
+          title: listing.details.title,
+          listingId: listing.listing.listing_id,
+          price: (+listing.listing.price).toLocaleString("en-us"),
+          quantity: quantity.toLocaleString("en-us"),
+        })
       }
 
-      message += `- Total: ${total.toLocaleString("en-us")} aUEC\n`
-      message += `- User Offer: ${(offer || total).toLocaleString(
-        "en-us",
-      )} aUEC\n`
+      message += req.t("market.delivery.total", {
+        total: total.toLocaleString("en-us"),
+      })
+      message += req.t("market.delivery.userOffer", {
+        offer: (offer || total).toLocaleString("en-us"),
+      })
       if (note) {
-        message += `\nNote from buyer:\n> ${note || "None"}`
+        message += req.t("market.delivery.noteFromBuyer", {
+          note: note || req.t("market.delivery.none"),
+        })
       }
 
       const {
@@ -1186,7 +1193,9 @@ marketRouter.post(
           actor_id: user.user_id,
           kind: "Delivery",
           cost: (offer || total).toString(),
-          title: `Items Sold to ${user.username}`,
+          title: req.t("market.delivery.itemsSoldTitle", {
+            username: user.username,
+          }),
           description: message,
         },
         listings,

--- a/src/api/routes/v1/offers/offers.ts
+++ b/src/api/routes/v1/offers/offers.ts
@@ -634,7 +634,7 @@ offerRouter.put(
         res.json(createResponse({ order_id: order.order_id }))
         return
       } else {
-        res.json(createResponse({ result: "Success" }))
+        res.json(createResponse({ result: req.t("success.generic") }))
         return
       }
     } else {
@@ -719,7 +719,7 @@ offerRouter.put(
         console.error(e)
       }
 
-      res.json(createResponse({ status: "Success" }))
+      res.json(createResponse({ status: req.t("success.generic") }))
     }
   },
 )
@@ -810,7 +810,7 @@ offersRouter.post(
     }
     res.status(201).json(
       createResponse({
-        result: "Success",
+        result: req.t("success.generic"),
       }),
     )
   },

--- a/src/api/routes/v1/orders/helpers.ts
+++ b/src/api/routes/v1/orders/helpers.ts
@@ -283,7 +283,7 @@ export async function handleStatusUpdate(req: any, res: any, status: string) {
     await manageOrderStatusUpdateDiscord(order, status)
     await sendStatusUpdateMessage(order, status)
 
-    res.status(200).json(createResponse({ result: "Success" }))
+    res.status(200).json(createResponse({ result: req.t("success.generic") }))
   } catch (e) {
     logger.error(`Failed to update order status: ${e}`)
   }
@@ -354,7 +354,7 @@ export async function handleAssignedUpdate(req: any, res: any) {
       assigned_id: null,
     })
   }
-  res.status(200).json(createResponse({ result: "Success" }))
+  res.status(200).json(createResponse({ result: req.t("success.generic") }))
 }
 
 export async function acceptApplicant(
@@ -438,7 +438,7 @@ export async function acceptApplicant(
   await database.clearOrderApplications(req.order.order_id)
   await createOrderNotifications(newOrders[0])
 
-  res.status(201).json(createResponse({ result: "Success" }))
+  res.status(201).json(createResponse({ result: req.t("success.generic") }))
 }
 
 export async function convert_order_search_query(

--- a/src/api/routes/v1/orders/orders.ts
+++ b/src/api/routes/v1/orders/orders.ts
@@ -952,7 +952,7 @@ ordersRouter.post(
 
     await createOrderReviewNotification(review[0])
 
-    res.status(200).json(createResponse({ result: "Success" }))
+    res.status(200).json(createResponse({ result: req.t("success.generic") }))
   },
 )
 
@@ -1215,7 +1215,7 @@ ordersRouter.post(
     }
 
     // TODO: Submit the application
-    res.status(201).json(createResponse({ result: "Success" }))
+    res.status(201).json(createResponse({ result: req.t("success.generic") }))
   },
 )
 
@@ -1294,7 +1294,7 @@ async function updateAssigned(
     })
   }
 
-  res.status(201).json(createResponse({ result: "Success" }))
+  res.status(201).json(createResponse({ result: req.t("success.generic") }))
 }
 
 ordersRouter.post(
@@ -1801,7 +1801,7 @@ ordersRouter.post(
     }
     res.status(201).json(
       createResponse({
-        result: "Success",
+        result: req.t("success.generic"),
       }),
     )
   },

--- a/src/api/routes/v1/profiles/helpers.ts
+++ b/src/api/routes/v1/profiles/helpers.ts
@@ -91,7 +91,7 @@ export async function authorizeProfile(
   try {
     const user = await database.getUser({ username })
     if (user.user_id !== user_id) {
-      return { success: false, error: "User already registered" }
+      return { success: false, error: "profiles.userAlreadyRegistered" }
     }
   } catch {}
 
@@ -135,5 +135,5 @@ export async function authorizeProfile(
     return { success: true, error: null }
   }
 
-  return { success: false, error: "Code not found" }
+  return { success: false, error: "profiles.codeNotFound" }
 }

--- a/src/api/routes/v1/profiles/profiles.ts
+++ b/src/api/routes/v1/profiles/profiles.ts
@@ -47,7 +47,7 @@ profileRouter.post("/auth/link", userAuthorized, async (req, res, next) => {
     } else {
       res.status(402).json(
         createErrorResponse({
-          message: result.error,
+          message: req.t(result.error),
           status: "error",
         }),
       )
@@ -108,7 +108,7 @@ profileRouter.post(
     // } catch (e) {
     //     console.error(e)
     // }
-    res.status(400).json({ error: "No access" })
+    res.status(400).json({ error: req.t("profiles.noAccess") })
   },
 )
 
@@ -209,7 +209,7 @@ profileRouter.put(
 
       res.json(
         createResponse({
-          message: "Locale updated successfully",
+          message: req.t("profiles.localeUpdated"),
           locale: updatedUsers[0].locale,
         }),
       )
@@ -217,7 +217,7 @@ profileRouter.put(
       logger.error("Error updating user locale:", error)
       res.status(500).json(
         createErrorResponse({
-          message: "Internal server error",
+          message: req.t("errors.internalServer"),
           status: "error",
         }),
       )
@@ -248,12 +248,12 @@ profileRouter.post(
 
     // Do checks first
     if (avatar_url && !avatar_url.match(external_resource_regex)) {
-      res.status(400).json({ error: "Invalid URL" })
+      res.status(400).json({ error: req.t("errors.invalidUrl") })
       return
     }
 
     if (banner_url && !banner_url.match(external_resource_regex)) {
-      res.status(400).json({ error: "Invalid URL" })
+      res.status(400).json({ error: req.t("errors.invalidUrl") })
       return
     }
 
@@ -261,7 +261,7 @@ profileRouter.post(
       display_name &&
       (display_name.length > 30 || display_name.length === 0)
     ) {
-      res.status(400).json({ error: "Invalid display name" })
+      res.status(400).json({ error: req.t("profiles.invalidDisplayName") })
       return
     }
 
@@ -304,7 +304,7 @@ profileRouter.post(
       await cdn.removeResource(old_banner)
     }
 
-    res.json({ result: "Success", ...newUsers[0] })
+    res.json({ result: req.t("success.generic"), ...newUsers[0] })
   },
 )
 
@@ -327,7 +327,7 @@ profileRouter.post(
 
     // TODO: Check for actual URL
     if (!webhook_url || !name) {
-      res.status(400).json({ error: "Invalid arguments" })
+      res.status(400).json({ error: req.t("errors.invalidArguments") })
       return
     }
 
@@ -340,10 +340,10 @@ profileRouter.post(
         user.user_id,
       )
     } catch (e) {
-      res.status(400).json({ error: "Invalid actions" })
+      res.status(400).json({ error: req.t("errors.invalidActions") })
       return
     }
-    res.json({ result: "Success" })
+    res.json({ result: req.t("success.generic") })
   },
 )
 
@@ -361,13 +361,13 @@ profileRouter.post(
 
     // Do checks first
     if (!webhook_id) {
-      res.status(400).json({ error: "Invalid arguments" })
+      res.status(400).json({ error: req.t("errors.invalidArguments") })
       return
     }
 
     const webhook = await database.getNotificationWebhook({ webhook_id })
     if (webhook?.user_id !== user.user_id) {
-      res.status(403).json({ error: "Unauthorized" })
+      res.status(403).json({ error: req.t("errors.unauthorized") })
       return
     }
 
@@ -375,7 +375,7 @@ profileRouter.post(
       webhook_id,
       user_id: user.user_id,
     })
-    res.json({ result: "Success" })
+    res.json({ result: req.t("success.generic") })
   },
 )
 
@@ -398,7 +398,7 @@ profileRouter.get("/user/:username/reviews", async (req, res, next) => {
   try {
     user = await database.getUser({ username: username }, { noBalance: true })
   } catch (e) {
-    res.status(400).json({ error: "Invalid user" })
+    res.status(400).json({ error: req.t("errors.invalidUser") })
     return
   }
 
@@ -430,14 +430,14 @@ profileRouter.get("/user/:username", async (req, res, next) => {
     try {
       user = await database.getUser({ username: username }, { noBalance: true })
     } catch (e) {
-      res.status(400).json({ error: "Invalid user" })
+      res.status(400).json({ error: req.t("errors.invalidUser") })
       return
     }
 
     res.json(await serializePublicProfile(user, { discord: !!requester }))
   } catch (e) {
     console.error(e)
-    res.status(400).json({ error: "Invalid user" })
+    res.status(400).json({ error: req.t("errors.invalidUser") })
     return
   }
 })
@@ -456,7 +456,7 @@ profileRouter.post(
     const { discord_order_share, discord_public } = req.body
 
     if (discord_order_share === undefined && discord_public === undefined) {
-      res.status(400).json({ error: "Invalid body" })
+      res.status(400).json({ error: req.t("errors.invalidBody") })
       return
     }
 
@@ -465,7 +465,7 @@ profileRouter.post(
       discord_public,
     })
 
-    res.json({ result: "Success" })
+    res.json({ result: req.t("success.generic") })
     return
   },
 )
@@ -484,7 +484,7 @@ profileRouter.post(
         try {
           cobj = await database.getContractor({ spectrum_id: contractor })
         } catch {
-          res.status(403).json({ error: "Invalid contractor" })
+          res.status(403).json({ error: req.t("errors.invalidContractor") })
           return
         }
 
@@ -492,7 +492,7 @@ profileRouter.post(
           !(await database.getMemberRoles(cobj.contractor_id, user.user_id))
             .length
         ) {
-          res.status(403).json({ error: "Invalid contractor" })
+          res.status(403).json({ error: req.t("errors.invalidContractor") })
           return
         }
 
@@ -505,7 +505,7 @@ profileRouter.post(
         await database.updateUserAvailability(user.user_id, null, selections)
       }
 
-      res.json({ result: "Success" })
+      res.json({ result: req.t("success.generic") })
       return
     } catch (e) {
       console.error(e)
@@ -524,7 +524,7 @@ profileRouter.get(
     try {
       cobj = await database.getContractor({ spectrum_id })
     } catch {
-      res.status(403).json({ error: "Invalid contractor" })
+      res.status(403).json({ error: req.t("errors.invalidContractor") })
       return
     }
 
@@ -578,7 +578,7 @@ profileRouter.post(
         discord_thread_channel_id: "1072580369251041330",
       },
     )
-    res.json({ result: "Success" })
+    res.json({ result: req.t("success.generic") })
     return
   },
 )

--- a/src/api/routes/v1/util/discord.ts
+++ b/src/api/routes/v1/util/discord.ts
@@ -20,6 +20,7 @@ import {
 } from "./webhooks.js"
 import logger from "../../../../logger/logger.js"
 import { env } from "../../../../config/env.js"
+import { t } from "./i18n.js"
 
 export const rest = new REST({ version: "10" }).setToken(
   env.DISCORD_API_KEY || "missing",
@@ -160,7 +161,9 @@ export async function rename_offer_thread(
     try {
       await rest.patch(Routes.channel(session.thread_id), {
         body: {
-          name: `order-${order.order_id.substring(0, 8)}`,
+          name: t("discord.thread.orderName", {
+            id: order.order_id.substring(0, 8),
+          }),
         },
       })
     } catch (error) {

--- a/src/api/routes/v1/util/webhooks.ts
+++ b/src/api/routes/v1/util/webhooks.ts
@@ -12,6 +12,7 @@ import { sendDM } from "./discord.js"
 import { cdn } from "../../../../clients/cdn/cdn.js"
 import logger from "../../../../logger/logger.js"
 import { formatMarketUrl } from "./urls.js"
+import { t } from "./i18n.js"
 
 export async function createNotificationWebhook(
   name: string,
@@ -157,24 +158,25 @@ export async function generateNewOfferMessage(
         url: `https://sc-market.space/offer/${session.id}`,
         // embed description
         // - text on 3rd row
-        description: `Discord User Details: <@${customer.discord_id}>
-                        
-                        ${lastOffer.description}`,
+        description: t("discord.userDetails", {
+          discordId: customer.discord_id,
+          description: lastOffer.description,
+        }),
         // custom embed fields: bold title/name, normal content/value below title
         // - located below description, above image.
         fields: [
           {
-            name: "Offer",
+            name: t("discord.fields.offer"),
             value: `${(+lastOffer.cost).toLocaleString("en-US")} aUEC`,
           },
           {
-            name: "Kind",
+            name: t("discord.fields.kind"),
             value: lastOffer.kind,
           },
           ...(lastOffer.collateral
             ? [
                 {
-                  name: "Collateral",
+                  name: t("discord.fields.collateral"),
                   value: `${(+lastOffer.cost).toLocaleString("en-US")} aUEC`,
                 },
               ]
@@ -221,24 +223,25 @@ export async function generateNewOrderMessage(
         url: `https://sc-market.space/contract/${order.order_id}`,
         // embed description
         // - text on 3rd row
-        description: `Discord User Details: <@${customer.discord_id}>
-                        
-                        ${order.description}`,
+        description: t("discord.userDetails", {
+          discordId: customer.discord_id,
+          description: order.description,
+        }),
         // custom embed fields: bold title/name, normal content/value below title
         // - located below description, above image.
         fields: [
           {
-            name: "Offer",
+            name: t("discord.fields.offer"),
             value: `${(+order.cost).toLocaleString("en-US")} aUEC`,
           },
           {
-            name: "Kind",
+            name: t("discord.fields.kind"),
             value: order.kind,
           },
           ...(order.collateral
             ? [
                 {
-                  name: "Collateral",
+                  name: t("discord.fields.collateral"),
                   value: `${(+order.cost).toLocaleString("en-US")} aUEC`,
                 },
               ]
@@ -264,8 +267,8 @@ export async function generateStatusUpdateMessage(
         author: {
           name: order.title,
         },
-        description: `Was: ${order.status}`,
-        title: `Order Status Updated - ${newStatus}`,
+        description: t("discord.status.was", { status: order.status }),
+        title: t("discord.status.orderUpdated", { status: newStatus }),
         url: `https://sc-market.space/contract/${order.order_id}`,
         timestamp: order.timestamp.toISOString(),
       },
@@ -288,7 +291,7 @@ export async function generateOfferStatusUpdateMessage(
         author: {
           name: offer.title,
         },
-        title: `Offer Status Updated - ${newStatus}`,
+        title: t("discord.status.offerUpdated", { status: newStatus }),
         url: `https://sc-market.space/offer/${session.id}`,
         timestamp: offer.timestamp.toISOString(),
       },
@@ -310,8 +313,8 @@ export async function generateAssignedMessage(
         author: {
           name: order.title,
         },
-        description: `Someone has been assigned to fulfill this order`,
-        title: `Order Assigned - ${assigned.username}`,
+        description: t("discord.assigned.description"),
+        title: t("discord.assigned.title", { username: assigned.username }),
         url: `https://sc-market.space/contract/${order.order_id}`,
         timestamp: order.timestamp.toISOString(),
       },
@@ -417,7 +420,7 @@ async function sendOrderWebhook(
   return await sendWebhook(
     {
       // the username to be displayed
-      username: "SC Market - Order Placed",
+      username: t("discord.usernames.orderPlaced"),
       // the avatar to be displayed
       avatar_url: "https://sc-market.space/assets/BG0TEXT1SHADOW1-Cqbbzppd.png",
 
@@ -448,21 +451,21 @@ async function sendOrderWebhook(
           // - located below description, above image.
           fields: [
             {
-              name: "Offer",
+              name: t("discord.fields.offer"),
               value: `${(+order.cost).toLocaleString("en-US")} aUEC`,
             },
             {
-              name: "Kind",
+              name: t("discord.fields.kind"),
               value: order.kind,
             },
             {
-              name: "Rush",
-              value: order.rush ? "True" : "False",
+              name: t("discord.fields.rush"),
+              value: order.rush ? t("common.yes") : t("common.no"),
             },
             ...(order.collateral
               ? [
                   {
-                    name: "Collateral",
+                    name: t("discord.fields.collateral"),
                     value: `${(+order.cost).toLocaleString("en-US")} aUEC`,
                   },
                 ]
@@ -488,9 +491,10 @@ async function sendOfferWebhook(
   return await sendWebhook(
     {
       // the username to be displayed
-      username: `SC Market - ${
-        type === "offer_create" ? "Offer Received" : "Counter Offer Received"
-      }`,
+      username:
+        type === "offer_create"
+          ? t("discord.usernames.offerReceived")
+          : t("discord.usernames.counterOfferReceived"),
       // the avatar to be displayed
       avatar_url: "https://sc-market.space/assets/BG0TEXT1SHADOW1-Cqbbzppd.png",
 
@@ -521,11 +525,11 @@ async function sendOfferWebhook(
           // - located below description, above image.
           fields: [
             {
-              name: "Offer",
+              name: t("discord.fields.offer"),
               value: `${(+most_recent.cost).toLocaleString("en-US")} aUEC`,
             },
             {
-              name: "Kind",
+              name: t("discord.fields.kind"),
               value: most_recent.kind,
             },
           ],
@@ -572,7 +576,7 @@ async function marketBidWebhook(
   const bidder = await database.getMinimalUser({ user_id: bid.user_bidder_id })
   return await sendWebhook(
     {
-      username: "SC Market - Bid Received",
+      username: t("discord.usernames.bidReceived"),
       // the avatar to be displayed
       avatar_url: "https://sc-market.space/assets/BG0TEXT1SHADOW1-Cqbbzppd.png",
       // // enable mentioning of individual users or roles, but not @everyone/@here
@@ -601,7 +605,7 @@ async function marketBidWebhook(
           // - located below description, above image.
           fields: [
             {
-              name: "Bid Amount",
+              name: t("discord.fields.bidAmount"),
               value: `${(+bid.bid).toLocaleString("en-US")} aUEC`,
             },
           ],
@@ -658,7 +662,7 @@ async function orderCommentWebhook(
   const author = await database.getMinimalUser({ user_id: comment.author })
   return await sendWebhook(
     {
-      username: "SC Market - Order Comment Received",
+      username: t("discord.usernames.orderCommentReceived"),
       // the avatar to be displayed
       avatar_url: "https://sc-market.space/assets/BG0TEXT1SHADOW1-Cqbbzppd.png",
       // // enable mentioning of individual users or roles, but not @everyone/@here
@@ -687,7 +691,7 @@ async function orderCommentWebhook(
           // - located below description, above image.
           fields: [
             {
-              name: "Comment",
+              name: t("discord.fields.comment"),
               value: comment.content,
             },
           ],
@@ -765,7 +769,7 @@ async function orderStatusWebhook(
   const actor = await database.getMinimalUser({ user_id: actor_id })
   return await sendWebhook(
     {
-      username: "SC Market - Order Status Updated",
+      username: t("discord.usernames.orderStatusUpdated"),
       // the avatar to be displayed
       avatar_url: "https://sc-market.space/assets/BG0TEXT1SHADOW1-Cqbbzppd.png",
       // // enable mentioning of individual users or roles, but not @everyone/@here
@@ -794,7 +798,7 @@ async function orderStatusWebhook(
           // - located below description, above image.
           fields: [
             {
-              name: "New Status",
+              name: t("discord.fields.newStatus"),
               value: new_status,
             },
           ],

--- a/src/tasks/timers.ts
+++ b/src/tasks/timers.ts
@@ -4,6 +4,7 @@ import {
   DBAuctionDetails,
   DBMarketListing,
 } from "../clients/database/db-models.js"
+import { t } from "../api/routes/v1/util/i18n.js"
 
 export async function process_auction(auction: DBAuctionDetails) {
   const complete = await database.getMarketListingComplete(auction.listing_id)
@@ -31,8 +32,17 @@ export async function process_auction(auction: DBAuctionDetails) {
         actor_id: winner.user_id,
         kind: "Delivery",
         cost: (+winning_bid.bid * quantity).toString(),
-        title: `Item Sold: ${complete.details.title} (x${quantity}) to ${winner.username}`,
-        description: `Complete the delivery of sold item ${complete.details.title} (x${quantity}) to ${winner.username}\n\n${complete.details.description}`,
+        title: t("market.delivery.itemSoldTitle", {
+          title: complete.details.title,
+          quantity,
+          username: winner.username,
+        }),
+        description: t("market.delivery.itemSoldDescription", {
+          title: complete.details.title,
+          quantity,
+          username: winner.username,
+          description: complete.details.description,
+        }),
       },
       [{ quantity, listing: complete }],
     )

--- a/tests/integration/i18n.test.ts
+++ b/tests/integration/i18n.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test"
+import assert from "node:assert"
+import express from "express"
+import {
+  i18nMiddleware,
+  addTranslationToRequest,
+  RequestWithI18n,
+} from "../../src/api/routes/v1/util/i18n.js"
+
+const app = express()
+app.use(i18nMiddleware)
+app.use((req: RequestWithI18n, _res, next) => {
+  if (req.query.lng) {
+    req.language = req.query.lng as string
+  } else if (req.headers["accept-language"]) {
+    req.language = (req.headers["accept-language"] as string).split(",")[0]
+  }
+  next()
+})
+app.use(addTranslationToRequest)
+app.get("/test", (req: RequestWithI18n, res) => {
+  res.json({ message: req.t("success.generic") })
+})
+
+function startServer() {
+  return new Promise<{ server: any; url: string }>((resolve) => {
+    const server = app.listen(0, () => {
+      const address = server.address() as { port: number }
+      resolve({ server, url: `http://localhost:${address.port}` })
+    })
+  })
+}
+
+describe("i18n middleware", () => {
+  it("responds in Ukrainian via ?lng=uk", async () => {
+    const { server, url } = await startServer()
+    const res = await fetch(`${url}/test?lng=uk`)
+    const body = await res.json()
+    assert.strictEqual(body.message, "Успіх")
+    server.close()
+  })
+
+  it("responds in English via ?lng=en", async () => {
+    const { server, url } = await startServer()
+    const res = await fetch(`${url}/test?lng=en`)
+    const body = await res.json()
+    assert.strictEqual(body.message, "Success")
+    server.close()
+  })
+
+  it("responds in Ukrainian via Accept-Language", async () => {
+    const { server, url } = await startServer()
+    const res = await fetch(`${url}/test`, {
+      headers: { "Accept-Language": "uk" },
+    })
+    const body = await res.json()
+    assert.strictEqual(body.message, "Успіх")
+    server.close()
+  })
+
+  it("falls back to English for unsupported language", async () => {
+    const { server, url } = await startServer()
+    const res = await fetch(`${url}/test?lng=zz`)
+    const body = await res.json()
+    assert.strictEqual(body.message, "Success")
+    server.close()
+  })
+})


### PR DESCRIPTION
## Summary
- localize authentication middleware responses using req.t and new `auth.notVerified` key
- translate profile routes and helpers, replacing all inline strings with i18n keys and adding missing translations
- swap raw "Success" strings in orders and offers modules for `success.generic`
- add i18n integration tests for query param, Accept-Language, and fallback behavior

## Testing
- `npx tsx --test tests/integration/i18n.test.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689686289d908325b134b08a0b9b69a9